### PR TITLE
Update Galaxy A5 variants for LineageOS 16.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 		<div class="projectbox">
 			<h1>LineageOS <a class="learnmore" href="https://lineageos.org">(Project site)</a></h1>
 			<h2>LineageOS is the most popular Android custom ROM. </h2>
-			<h3>LOS 16.0 (SM-A500FU only)</h3>
+			<h3>LOS 16.0 (All Galaxy A5 variants)</h3>
 			<h2>The newest version of LineageOS (Android 9 PIE), ported to the Galaxy A5.</h2>
 			<a href="https://github.com/DeadSquirrel01/lineage-16_a5_releases/releases" class="button">Download</a>
 			<h3>LOS 15.1 (SM-A500FU only)</h3>


### PR DESCRIPTION
As the latest release (20190225) is compatible with all Galaxy A5 variants, I updated the text "SM-A500FU only" to "All Galaxy A5 variants"